### PR TITLE
Update 2026

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,18 +10,22 @@ jobs:
   gradle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '21'
 
-      # Execute Gradle commands in GitHub Actions workflows
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
-      - name: Run test with coverage
-        run: ./gradlew runOnGitHub
+      - name: Run tests with coverage
+        run: ./gradlew test
 
-      # Send JaCoCo reports to codecov
-      - run: bash <(curl -s https://codecov.io/bash)
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: build/reports/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,8 +43,6 @@ dependencies {
 	// testing
 	testImplementation("com.h2database:h2:2.4.240")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")
-    testImplementation("jakarta.servlet:jakarta.servlet-api:6.1.0")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,13 +12,13 @@ version = "0.0.1-SNAPSHOT"
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
 tasks.withType<JavaCompile> {
-    targetCompatibility = "21"
-    sourceCompatibility = "21"
+    targetCompatibility = "25"
+    sourceCompatibility = "25"
 }
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
-	id("org.springframework.boot") version "3.4.2"
+	id("org.springframework.boot") version "4.0.2"
 	id("io.spring.dependency-management") version "1.1.7"
-	kotlin("jvm") version "1.9.25"
-	kotlin("plugin.spring") version "1.9.25"
-	kotlin("plugin.jpa") version "1.9.25"
+	kotlin("jvm") version "2.3.0"
+	kotlin("plugin.spring") version "2.3.0"
+	kotlin("plugin.jpa") version "2.3.0"
 	jacoco
 }
 
@@ -36,7 +36,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
 	// testing
-	testImplementation("com.h2database:h2:2.3.232")
+	testImplementation("com.h2database:h2:2.4.240")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
@@ -60,7 +60,7 @@ tasks.jacocoTestReport {
 }
 
 jacoco {
-	toolVersion = "0.8.12"
+	toolVersion = "0.8.14"
 }
 
 tasks.jacocoTestReport {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
-	id("org.springframework.boot") version "4.0.2"
+	id("org.springframework.boot") version "3.4.2"
 	id("io.spring.dependency-management") version "1.1.7"
-	kotlin("jvm") version "2.3.0"
-	kotlin("plugin.spring") version "2.3.0"
-	kotlin("plugin.jpa") version "2.3.0"
+	kotlin("jvm") version "2.2.10"
+	kotlin("plugin.spring") version "2.2.10"
+	kotlin("plugin.jpa") version "2.2.10"
 	jacoco
 }
 
@@ -14,6 +14,11 @@ java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(21)
 	}
+}
+
+tasks.withType<JavaCompile> {
+    targetCompatibility = "21"
+    sourceCompatibility = "21"
 }
 
 repositories {
@@ -38,13 +43,19 @@ dependencies {
 	// testing
 	testImplementation("com.h2database:h2:2.4.240")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")
+    testImplementation("jakarta.servlet:jakarta.servlet-api:6.1.0")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 kotlin {
-	compilerOptions {
-		freeCompilerArgs.addAll("-Xjsr305=strict")
-	}
+    jvmToolchain(21)
+
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            "-Xjsr305=strict",
+        )
+    }
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
 	id("org.springframework.boot") version "3.4.2"
 	id("io.spring.dependency-management") version "1.1.7"
-	kotlin("jvm") version "2.2.10"
-	kotlin("plugin.spring") version "2.2.10"
-	kotlin("plugin.jpa") version "2.2.10"
+	kotlin("jvm") version "2.3.0"
+	kotlin("plugin.spring") version "2.3.0"
+	kotlin("plugin.jpa") version "2.3.0"
 	jacoco
 }
 
@@ -12,13 +12,13 @@ version = "0.0.1-SNAPSHOT"
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(25)
+		languageVersion = JavaLanguageVersion.of(21)
 	}
 }
 
 tasks.withType<JavaCompile> {
-    targetCompatibility = "25"
-    sourceCompatibility = "25"
+    targetCompatibility = "21"
+    sourceCompatibility = "21"
 }
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,11 +16,6 @@ java {
 	}
 }
 
-tasks.withType<JavaCompile> {
-    targetCompatibility = "21"
-    sourceCompatibility = "21"
-}
-
 repositories {
 	mavenCentral()
 }
@@ -54,6 +49,11 @@ kotlin {
             "-Xjsr305=strict",
         )
     }
+}
+
+tasks.withType<JavaCompile> {
+    targetCompatibility = "21"
+    sourceCompatibility = "21"
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-	id("org.springframework.boot") version "3.4.2"
+	id("org.springframework.boot") version "3.5.10"
 	id("io.spring.dependency-management") version "1.1.7"
 	kotlin("jvm") version "2.3.0"
 	kotlin("plugin.spring") version "2.3.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     container_name: profesores_sql
     restart: always
     environment:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/test/kotlin/com/uqbar/profesores/MateriaControllerWebMvcTest.kt
+++ b/src/test/kotlin/com/uqbar/profesores/MateriaControllerWebMvcTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -17,7 +17,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
  */
 @WebMvcTest(controllers = [MateriaController::class])
 class MateriaControllerWebMvcTest {
-   @MockBean
+   @MockitoBean
    lateinit var materiaService: MateriaService
 
    @Autowired


### PR DESCRIPTION
- intentamos subir la versión de JDK pero no es compatible con la última versión de Spring 3.4.2
- última versión del plugin de Kotlin (2.3.0)
- última versión de Springboot (3.4.2) "oficial", la 4 soporta JDK 25 pero tiene muchos problemas en las dependencias granulares
- subimos la versión de gradle a 9.3.x
- cambiamos la anotación deprecada para usar MockitoBean